### PR TITLE
Fix update title from BrowserWindow

### DIFF
--- a/src/main/core/LauncherWindow.ts
+++ b/src/main/core/LauncherWindow.ts
@@ -141,6 +141,11 @@ export class LauncherWindow {
             },
         });
 
+        // https://github.com/electron/electron/issues/1594#issuecomment-419741626
+        mainWindow.on('page-title-updated', (evt) => {
+            evt.preventDefault();
+        });
+
         mainWindow.webContents.setWindowOpenHandler((data) => {
             shell.openExternal(data.url);
             return { action: 'deny' };


### PR DESCRIPTION
При использование navigate(-1) стандартный mainWindow.title объявленный в BrowserWindow не обновлялся, пропадал и заменялся на стандартное имя страницы "заглушки" index.html. https://github.com/electron/electron/issues/1594 данное исправление взято из этого issues. SET_TITLE добавленный мной я думаю оставить как фишку, позволяя через setTitlebarTitleText('') менять заголовок окна